### PR TITLE
fix: storage class name

### DIFF
--- a/components/apiconnect/variants/cloudprovider/azure/storage-class.yaml
+++ b/components/apiconnect/variants/cloudprovider/azure/storage-class.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/managed-by: ibm-apiconnect
     app.kubernetes.io/name: apiconnect-small
 spec:
-  storageClassName: managed-premium
+  storageClassName: managed-csi

--- a/components/eventstreams/variants/cloudprovider/azure/storage-class.yaml
+++ b/components/eventstreams/variants/cloudprovider/azure/storage-class.yaml
@@ -7,7 +7,7 @@ spec:
   strimziOverrides:
     kafka:
       storage:
-        class: managed-premium
+        class: managed-csi
     zookeeper:
       storage:
-        class: managed-premium
+        class: managed-csi

--- a/components/mq/variants/cloudprovider/azure/storage-class.yaml
+++ b/components/mq/variants/cloudprovider/azure/storage-class.yaml
@@ -6,8 +6,8 @@ spec:
   queueManager:
     storage:
       queueManager:
-        class: managed-premium
+        class: managed-csi
       persistedData:
-        class: managed-premium
+        class: managed-csi
       recoveryLogs:
-        class: managed-premium
+        class: managed-csi

--- a/components/openshift-logging/variants/cloudprovider/azure/storage-class-clusterlogging.yaml
+++ b/components/openshift-logging/variants/cloudprovider/azure/storage-class-clusterlogging.yaml
@@ -7,5 +7,5 @@ spec:
   logStore:
     elasticsearch:
       storage:
-        storageClassName: managed-premium
+        storageClassName: managed-csi
    

--- a/components/platformnavigator/variants/cloudprovider/azure-nfs/zen-configmap.yaml
+++ b/components/platformnavigator/variants/cloudprovider/azure-nfs/zen-configmap.yaml
@@ -6,7 +6,7 @@ data:
   zen: |-
     storage_data:
       storageClass: azurefile-csi-nfs
-      zenCoreMetaDbStorageClass: managed-premium
+      zenCoreMetaDbStorageClass: managed-csi
     scale_data:
       Usermgmt:
         name: usermgmt

--- a/components/platformnavigator/variants/cloudprovider/azure/pvc.yaml
+++ b/components/platformnavigator/variants/cloudprovider/azure/pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nfs-pwx-claim
   namespace: rook-nfs
 spec:
-  storageClassName: managed-premium
+  storageClassName: managed-csi
   accessModes:
   - ReadWriteOnce
   resources:

--- a/components/platformnavigator/variants/cloudprovider/azure/zen-configmap.yaml
+++ b/components/platformnavigator/variants/cloudprovider/azure/zen-configmap.yaml
@@ -6,7 +6,7 @@ data:
   zen: |-
     storage_data:
       storageClass: platform-navigator-storage
-      zenCoreMetaDbStorageClass: managed-premium
+      zenCoreMetaDbStorageClass: managed-csi
     scale_data:
       Usermgmt:
         name: usermgmt

--- a/envs/azure-nfs/nonprod/mq/test/test-azure-storageclasses-and-license.rego
+++ b/envs/azure-nfs/nonprod/mq/test/test-azure-storageclasses-and-license.rego
@@ -1,10 +1,10 @@
 package azure.nonprod.mq
 
-# Validate that the storage class is managed-premium
+# Validate that the storage class is managed-csi
 deny[msg] {
     input.kind = "QueueManager"
-    not input.spec.queueManager.storage.queueManager.class = "managed-premium"
-    msg = "Storageclass should be managed-premium"
+    not input.spec.queueManager.storage.queueManager.class = "managed-csi"
+    msg = "Storageclass should be managed-csi"
 }
 
 # Validate that the license is correct 

--- a/envs/azure/nonprod/mq/test/test-azure-storageclasses-and-license.rego
+++ b/envs/azure/nonprod/mq/test/test-azure-storageclasses-and-license.rego
@@ -1,10 +1,10 @@
 package azure.nonprod.mq
 
-# Validate that the storage class is managed-premium
+# Validate that the storage class is managed-csi
 deny[msg] {
     input.kind = "QueueManager"
-    not input.spec.queueManager.storage.queueManager.class = "managed-premium"
-    msg = "Storageclass should be managed-premium"
+    not input.spec.queueManager.storage.queueManager.class = "managed-csi"
+    msg = "Storageclass should be managed-csi"
 }
 
 # Validate that the license is correct 


### PR DESCRIPTION
In default ARO 4.12 setup the name of the storage class is `managed-csi`, not `managed-premium`